### PR TITLE
Processes ordered lists correctly, and removes text comments

### DIFF
--- a/package/src/module.js
+++ b/package/src/module.js
@@ -18,7 +18,7 @@ export const makeDeserializer = (jsx) => {
 
   function deserializeList(el, imageTags) {
     const siblings = getSiblings(el)
-    const type = 'UL'
+    const type = getListType(el)
     const list_wrapper = document.createElement(type)
     for (let i = 0; i < siblings.length; i++) {
       list_wrapper.appendChild(siblings[i])
@@ -91,6 +91,15 @@ export const makeDeserializer = (jsx) => {
         const attrs = ELEMENT_TAGS[nodeName](el)
         return jsx('element', attrs, children)
       }
+      if (
+        el.attributes &&
+        el.attributes.getNamedItem('class') &&
+        el.attributes
+          .getNamedItem('class')
+          .value.match(/msocomanchor|MsoCommentText/g)
+      ) {
+        return null  // word comment anchor and text annotations
+      }
       if (nodeName === 'H3' || nodeName === 'H2' || nodeName === 'H1') {
         return jsx('element', { type: nodeName, className: nodeName }, children)
       }
@@ -160,13 +169,10 @@ function isList(el) {
 }
 
 // Future functionality: Ordered Lists
-function isOrderedList(el) {
+function getListType(el) {
   const val = el.textContent[0]
   const regex = /^\d+$/
-  if (regex.test(val)) {
-    return true
-  }
-  return false
+  return regex.test(val) ? 'OL' : 'UL'
 }
 
 
@@ -181,7 +187,7 @@ function getTextfromList(el) {
       result.push(child)
     } else if (child.nodeName === 'SPAN') {
       child.textContent = child.textContent.replace(
-        /(^(\W)(?=\s)*)|(o\s)(?!\w)/gm,
+        /(^(\W)(?=\s)*)|(o\s)(?!\w)|[0-9]\)/gm,
         ''
       )
       result.push(child)

--- a/package/tests/deserialize_list.spec.js
+++ b/package/tests/deserialize_list.spec.js
@@ -21,3 +21,15 @@ test('deserialize list to equal {type: "ul", className: "H3", children: Array(1)
   }]
   expect(deserialize(parsed_html.body)).toStrictEqual(output)
 })
+
+test('deserialize ordered list to equal {type: "ol", className: "H3", children: Array(1) }', () => {
+  const deserialize = makeDeserializer(jsx)
+  const input = "<body lang=EN-US style='tab-interval:.5in'><!--StartFragment--> <p class=MsoListParagraph style='text-indent:-.25in;mso-list:l0 level1 lfo1'><![if !supportLists]><span style='font-family:Symbol;mso-fareast-font-family:Symbol;mso-bidi-font-family: Symbol;mso-bidi-font-style:italic'><span style='mso-list:Ignore'>1)<span style='font:7.0pt \"Times New Roman\"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><![endif]><i>Level 1.3<o:p></o:p></i></p> <!--EndFragment--> </body>";
+  const parsed_html = new DOMParser().parseFromString(input, 'text/html')
+  const output = [{ "type": "p", "className": "P", "children": [{ "text": " " }] }, {
+    "type": "numbered-list", "children": [{
+      "type": "list-item", className: "level1", "children": [{ "italic": true, "text": "Level 1.3" }]
+    }]
+  }]
+  expect(deserialize(parsed_html.body)).toStrictEqual(output)
+})


### PR DESCRIPTION
I took a dive into your library because I needed it, and I had a couple things that I needed right off the bat.
1. OLs looked like they were "yet to be done" 
2. Comments in MS word come across as an embedded anchor link and then the text of the comment as an annotation. I just wanted to remove it entirely